### PR TITLE
Add before/after comparison

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -173,6 +173,7 @@ export function activate(context: vscode.ExtensionContext) {
         try {
           progress.report({ message: 'Applying Brush...' });
 
+          await vscode.commands.executeCommand('workbench.action.files.saveWithoutFormatting');
           const completion = await vscode.commands.executeCommand<string | undefined>('gptbrushes.providers.' + brush.type + '.apply', new BrushInvocation(brush, selectedText, cancelToken, progress));
 
           if (editor.document.version !== originalVersion) {
@@ -189,6 +190,7 @@ export function activate(context: vscode.ExtensionContext) {
           }
 
           await editor.edit((editBuilder) => editBuilder.replace(originalSelection, completion));
+          await vscode.commands.executeCommand('workbench.files.action.compareWithSaved');
           progress.report({ message: 'Brush applied.' });
         } catch (error) {
           if (cancelToken.isCancellationRequested) {


### PR DESCRIPTION
This PR adds a before/after comparison feature, which is automatically displayed after applying a code brush.

This is useful because sometimes it's not obvious without a side-by-side diff what changes GPT-4 has made to the code. It also makes it easier to see if the model has made any mistakes or edited parts that it wasn't supposed to.

Here is an example of running the "Translate to German" brush on a section of the README.md file:
![image](https://user-images.githubusercontent.com/10100202/235358530-42b85b26-3061-4fd9-a52d-d1a6ba6fbbc1.png)